### PR TITLE
fix: "end_line", "start_line" weren't supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ const memoizedFindBestFileMatch = memoize(findBestFileMatch)
 async function buildStepAnnotation(cucumberError, status, errorType) {
     return {
         path: (await memoizedFindBestFileMatch(cucumberError.file)) || cucumberError.file,
-        start_line: cucumberError.line,
-        end_line: cucumberError.line,
+        start_line: cucumberError.line || 0,
+        end_line: cucumberError.line || 0,
         start_column: 0,
         end_column: 0,
         annotation_level: status,


### PR DESCRIPTION
try to fix the issue #26 

If the line of the failed step can not be found on the report, set the line to 0. The annotation will be displayed at the first line of the file