### PR TITLE
feat: set GitHub default token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ inputs:
   access-token:
     description: "github token"
     required: true
+    default: ${{ github.token }}
   path:
     description: "glob to cucumber json files"
     required: true


### PR DESCRIPTION
This adds default `github.token`, which is the same as `secrets.GITHUB_TOKEN` .